### PR TITLE
Add react-virtualized-select as dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.1.3] - 2018-11-02
+### Fix
+- Add missing dependency `react-virtualized-select`
+
 ## [0.1.2] - 2018-10-31
 ### Changed
 - Updated react-cimpress-users version

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-cimpress-templates",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-cimpress-templates",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6725,8 +6725,7 @@
     "dom-helpers": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.3.1.tgz",
-      "integrity": "sha512-2Sm+JaYn74OiTM2wHvxJOo3roiq/h25Yi69Fqk269cNUwIXsCvATB6CRSFC9Am/20G2b28hGv/+7NiWydIrPvg==",
-      "dev": true
+      "integrity": "sha512-2Sm+JaYn74OiTM2wHvxJOo3roiq/h25Yi69Fqk269cNUwIXsCvATB6CRSFC9Am/20G2b28hGv/+7NiWydIrPvg=="
     },
     "dom-walk": {
       "version": "0.1.1",
@@ -11486,7 +11485,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/react-input-autosize/-/react-input-autosize-2.2.1.tgz",
       "integrity": "sha512-3+K4CD13iE4lQQ2WlF8PuV5htfmTRLH6MDnfndHM6LuBRszuXnuyIfE7nhSKt8AzRBZ50bu0sAhkNMeS5pxQQA==",
-      "dev": true,
       "requires": {
         "prop-types": "^15.5.8"
       }
@@ -11504,8 +11502,7 @@
     "react-lifecycles-compat": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
-      "dev": true
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "react-mentions": {
       "version": "1.2.2",
@@ -11557,7 +11554,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/react-select/-/react-select-1.3.0.tgz",
       "integrity": "sha512-g/QAU1HZrzSfxkwMAo/wzi6/ezdWye302RGZevsATec07hI/iSxcpB1hejFIp7V63DJ8mwuign6KmB3VjdlinQ==",
-      "dev": true,
       "requires": {
         "classnames": "^2.2.4",
         "prop-types": "^15.5.8",
@@ -11717,7 +11713,6 @@
       "version": "9.20.1",
       "resolved": "https://registry.npmjs.org/react-virtualized/-/react-virtualized-9.20.1.tgz",
       "integrity": "sha512-xIWxBsyNAjceqD3hsE0nw5TcDVxKbIepsHhvS2XneHmNz0KlKxdLdGBmGZBM9ZesEmbZ5EO0Sw70TB1MeCmpbQ==",
-      "dev": true,
       "requires": {
         "babel-runtime": "^6.26.0",
         "classnames": "^2.2.3",
@@ -11731,7 +11726,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/react-virtualized-select/-/react-virtualized-select-3.1.3.tgz",
       "integrity": "sha512-u6j/EfynCB9s4Lz5GGZhNUCZHvFQdtLZws7W/Tcd/v03l19OjpQs3eYjK82iYS0FgD2+lDIBpqS8LpD/hjqDRQ==",
-      "dev": true,
       "requires": {
         "babel-runtime": "^6.11.6",
         "prop-types": "^15.5.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-cimpress-templates",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Template selection",
   "main": "./lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -53,13 +53,13 @@
     "jwt-decode": "^2.2.0",
     "react": "^16.4.2",
     "react-dom": "^16.4.2",
-    "react-virtualized-select": "^3.1.3",
     "style-loader": "^0.21.0"
   },
   "dependencies": {
     "classnames": "^2.2.6",
     "i18next": "^11.5.0",
     "react-cimpress-comment": "^0.6.10",
+    "react-virtualized-select": "^3.1.3",
     "react-cimpress-users": "^0.4.0",
     "react-i18next": "^7.10.1",
     "react-portal": "^4.1.5",


### PR DESCRIPTION
Using the package there is amissing dependency, `react-virtualized-select`. It is added as a devDependency.

I have checked if it could be a peerDependency from the package `@cimpress/react-components` but it's not. It's actively being used in the file `TemplateSelect.js`